### PR TITLE
Use conventional mode toggle

### DIFF
--- a/mode-line-in-header.el
+++ b/mode-line-in-header.el
@@ -49,9 +49,9 @@
   :lighter " mode-header"
   :global nil
   :group 'editing-basics
-  (if (not header-line-format)
+  (if mode-line-in-header
       (setq header-line-format mode-line-format
-            mode-line-format   nil)
+            mode-line-format nil)
     (setq mode-line-format header-line-format
           header-line-format nil))
   (force-mode-line-update))


### PR DESCRIPTION
Rather than looking at header-line-format to decide whether we're enabling or disabling the mode, just use the mode variable.